### PR TITLE
Web UI: Properly handle only one URL in pin request

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,7 +565,7 @@
                 urls = decoded_object["result"]["http_request"]["params"]["urls"]
                 request_data = decoded_object["result"]["http_request"]["params"]["data"]["data"]
                 let pin_func = "get_pin";
-                if (urls[0].endsWith("set_pin") || urls[1].endsWith("set_pin")) {
+                if (urls.some(url => url.endsWith("set_pin"))) {
                     pin_func = "set_pin";
                 }
                 document.getElementById("pin_request").innerHTML = pin_func + "<br>data: " + request_data;


### PR DESCRIPTION
This fixes an out-of-bounds access when the pin request contains only
one URL. Up until Jade firmware version 1.0.34 the pin request always
had two strings in the "urls" parameter. This changed with version
1.0.35.

Fixes #15